### PR TITLE
Adding support for unescaped request uri

### DIFF
--- a/urlutil.go
+++ b/urlutil.go
@@ -55,7 +55,9 @@ func ParseWithScheme(u string) (*URL, error) {
 	U, err := url.Parse(u)
 	if err != nil {
 		// try to reparse without the request path
-		forwardSlashPosition := strings.Index(u, "/")
+		// attempt to find the forward slash at the beginning of the path
+		schemeDoubleForwardSlash := strings.Index(u, "//") + 2
+		forwardSlashPosition := schemeDoubleForwardSlash + strings.Index(u[schemeDoubleForwardSlash:], "/")
 		if forwardSlashPosition > 0 {
 			origReqURI = u[forwardSlashPosition:]
 			u = u[:forwardSlashPosition]

--- a/urlutil_test.go
+++ b/urlutil_test.go
@@ -43,4 +43,9 @@ func TestParse(t *testing.T) {
 	require.Nil(t, err, "could not parse url")
 	U.Port = "15000"
 	require.Equal(t, "https://a.b.c.d:15000", U.String(), "port not replaced")
+
+	// replacing port
+	U, err = Parse("https://a.b.c.d//d")
+	require.Nil(t, err, "could not parse url")
+	require.Equal(t, "https://a.b.c.d:443//d", U.String(), "unexpected url")
 }


### PR DESCRIPTION
## Description
This PR makes URL like `https:/xxx//yy` parseable